### PR TITLE
bugfix: exclude folderId from getting encrypted

### DIFF
--- a/src/bitwardentools/client.py
+++ b/src/bitwardentools/client.py
@@ -1070,6 +1070,7 @@ class Client(object):
             for k, v in val.items():
                 if k not in [
                     "id",
+                    "folderId",
                     "organizationId",
                     "lastKnownRevisionDate",
                     "revisionDate",


### PR DESCRIPTION
Otherwise the server cannot find the folder and throw an "Folder doesn't exist" error.

When using `client.create_item(**j)` with
```
{
...
"folderId": "679c3527-ca88-4cf8-9760-fac6dd3067fb",
...
}
```

then `Client.encrypt_item` will encrypt it - and cause a "Folder doesn't exist" error on the server.